### PR TITLE
fix: refine layout and sizing of screenshots in AppBanner, Header, and HowItWorks components

### DIFF
--- a/components/AppBanner.js
+++ b/components/AppBanner.js
@@ -179,10 +179,14 @@ function AppBanner() {
                     {/* <div className="relative">
                       <IPhoneFrame src={src} className={"rounded-4xl h-full"} />
                     </div> */}
-                    <div className="absolute top-2 left-3 w-[calc(100%-24px)] h-[calc(100%-16px)] rounded-4xl overflow-hidden">
+                    <div className="absolute top-2 md:top-3 lg:top-2 left-3 sm:left-4 md:left-4 lg:left-3 md:w-[92%] h-[calc(100%-18px)] md:h-[calc(100%-22px)] aspect-[9/19.5] lg:w-[calc(100%-24px)] lg:h-[calc(100%-16px)] rounded-4xl overflow-hidden">
                       <SingleScreenshot src={src} />
                     </div>
-                    <img src="/misc/iphone-frame.webp" alt="iphone-frame" className="relative z-10 h-full" />
+                    <img
+                      src="/misc/iphone-frame.webp"
+                      alt="iphone-frame"
+                      className="relative z-10 h-[103%] w-auto pointer-events-none"
+                    />
 
                     {/* Floating elements around phones */}
                     {index === 0 && (

--- a/components/Header.js
+++ b/components/Header.js
@@ -50,7 +50,7 @@ function Header({ header, partners }) {
                   }}
                   className="relative h-[548px] 2xs:h-[720px] sm:h-[648px] md:h-[548px] rounded-[3rem]"
                 >
-                  <div className="absolute top-[10px] left-[12px] w-[calc(100%-24px)] h-[calc(100%-16px)] rounded-[1rem] 2xs:rounded-[2rem] overflow-hidden">
+                  <div className="absolute top-[10px] left-[12px] w-[calc(100%-24px)] h-[calc(100%-16px)] rounded-[2rem] overflow-hidden">
                     <SingleScreenshot src={header.screenshots[0]} />
                   </div>
                   <img src="/misc/iphone-frame.webp" alt="iphone-frame" className="relative z-10 h-full" />

--- a/components/HowItWorks.js
+++ b/components/HowItWorks.js
@@ -125,7 +125,7 @@ function HowItWorks({ howItWorks }) {
                     <div className="relative group max-w-xs mx-auto">
                       <div className="relative h-80 lg:h-96 w-full transition-transform duration-300 group-hover:scale-105">
                         {/* Screenshot container — precisely aligned */}
-                        <div className="absolute top-[7px] left-[7px] lg:left-[9px] w-[91%] lg:w-[55%] h-full rounded-2xl lg:rounded-3xl overflow-hidden">
+                        <div className="absolute left-[7px] lg:left-[9px] top-[4px] md:top-[6px] lg:top-[7px] w-[91.5%] lg:w-[55%] h-full rounded-2xl lg:rounded-3xl overflow-hidden">
                           <SingleScreenshot src={step.image} />
                         </div>
 
@@ -133,7 +133,7 @@ function HowItWorks({ howItWorks }) {
                         <img
                           src="/misc/iphone-frame.webp"
                           alt="iphone-frame"
-                          className="relative z-10 h-[104%] lg:h-[103%] w-auto pointer-events-none"
+                          className="relative z-10 h-[102%] lg:h-[103%] w-auto pointer-events-none"
                         />
                       </div>
                     </div>


### PR DESCRIPTION
fix: refine layout and sizing of screenshots in AppBanner, Header, and HowItWorks components